### PR TITLE
Fix end of session behavior

### DIFF
--- a/licking_MCC.py
+++ b/licking_MCC.py
@@ -381,6 +381,7 @@ if useCamera == 'True':
 shutterThread = None #Add this so that the thread can be resolved before shutterThread is instanced
 rig.AbortEvent.set() #Set the abort event, which will be turned off to start the session
 rig.TrialEvent.set() #Set the trial event, which will be turned off to start the session
+rig.cleanRun.clear()
 
 def runSession():
     #Final Check
@@ -398,7 +399,6 @@ def runSession():
     #if useLED == 'True' or useLED == 'Cue': led.white_on()
     
     #%% Open the trial loop
-    cleanRun = False
     curPos = 1 # Initial position of table should be 1
     try:
         for trialN, spoutN in enumerate(TubeSeq): #trialN was index, spoutN was trial #spoutN = 2; trialN = 1
@@ -557,11 +557,11 @@ def runSession():
             print('\n=====  Inter-Trial Interval =====\n')
         
         #Note a clean run
-        cleanRun = True
+        rig.cleanRun.set()
         
     #%% Ending the session
     finally:
-        if not cleanRun:
+        if not rig.cleanRun.is_set():
             print("Session interrupted")
     
         if shutterThread and shutterThread.is_alive():
@@ -585,16 +585,15 @@ def runSession():
             num_licks_trial = [len(i) if i is not None else None for i in licks[spout]]
             print(spout, num_licks_trial)
             
-            tot_licks = np.concatenate(licks[spout])
-            print("Total number of licks on {}: {}".format(spout, len(tot_licks)))
+            if licks[spout]:  # Check if list is non-empty
+                tot_licks = np.concatenate(licks[spout])
+                print("Total number of licks on {}: {}".format(spout, len(tot_licks)))
+            else:
+                print("No licks recorded for {}.".format(spout))                
         
         rig.AbortEvent.set() #Tell the GUI to close
-        if not cleanRun:
-            easygui.msgbox(msg="Session was interrupted: Check terminal for errors", title="Session Interrupted")
-        else:
-            easygui.msgbox(msg="Remove rat from the box to its home cage", title="Session Finished")
 
 #%%
-sessionThread = threading.Thread(target=runSession,daemon=True)
+sessionThread = threading.Thread(target=runSession,daemon=False)
 sessionThread.start()
 rig.TrialGui(paramsFile, outputFile, subjID)

--- a/licking_beambk_Camera.py
+++ b/licking_beambk_Camera.py
@@ -395,6 +395,7 @@ if useCamera == 'True':
 #Final Check
 rig.AbortEvent.set() #Set the abort event, which will be turned off to start the session
 rig.TrialEvent.set() #Set the trial event, which will be turned off to start the session
+rig.cleanRun.clear()
 #guiThread = threading.Thread(target=rig.TrialGui, kwargs={'paramsFile':paramsFile, 'outputFile':outputFile, 'subjID':subjID}, daemon=True)
 #guiThread.start()
 def runSession():
@@ -413,7 +414,6 @@ def runSession():
     if useLED == 'True' or useLED == 'Cue': led.white_on()
     
     #%% Open the trial loop
-    cleanRun = False
     cur_pos = 1     # Initial position of table should be 1
     dest_pos = TubeSeq[0] #Set initial destination
     try:
@@ -636,11 +636,11 @@ def runSession():
             print('\n=====  Inter-Trial Interval =====\n')
         
         #Note a clean run
-        cleanRun = True
+        rig.cleanRun.set()
         
     #%% Ending the session
     finally:
-        if not cleanRun:
+        if not rig.cleanRun.is_set():
             print("Session interrupted")
             
         # turn off LEDs and Intan outs
@@ -675,16 +675,13 @@ def runSession():
             num_licks_trial = [len(i) if i is not None else None for i in licks[spout]]
             print(spout, num_licks_trial)
             
-            tot_licks = np.concatenate(licks[spout])
-            print("Total number of licks on {}: {}".format(spout, len(tot_licks)))
+            if licks[spout]:  # Check if list is non-empty
+                tot_licks = np.concatenate(licks[spout])
+                print("Total number of licks on {}: {}".format(spout, len(tot_licks)))
+            else:
+                print("No licks recorded for {}.".format(spout))                
                 
         rig.AbortEvent.set() #Tell the GUI to close
-        print("checkpoint A")
-        if not cleanRun:
-            easygui.msgbox(msg="Session was interrupted: Check terminal for errors", title="Session Interrupted")
-        else:
-            easygui.msgbox(msg="Remove rat from the box to its home cage", title="Session Finished")
-        print("checkpoint B")
 
 #%%
 sessionThread = threading.Thread(target=runSession,daemon=False)

--- a/rig_funcs.py
+++ b/rig_funcs.py
@@ -148,10 +148,18 @@ def align_zero(step=stepPin, direction=directionPin,enable=enablePin,ms1=ms1Pin,
         print("Hall sensor read as 'off' through a full rotation, check hardware")
         return        
     
+        
+    
     if rotate == 'clockwise':
-        motora.turn(adjust_steps, Motor.CLOCKWISE)
+        if adjust_steps<0:
+            motora.turn(abs(adjust_steps), Motor.ANTICLOCKWISE)
+        else:
+            motora.turn(abs(adjust_steps), Motor.CLOCKWISE)
     elif rotate == 'anticlockwise':
-        motora.turn(adjust_steps, Motor.ANTICLOCKWISE)
+        if adjust_steps<0:
+            motora.turn(abs(adjust_steps), Motor.CLOCKWISE)
+        else:
+            motora.turn(abs(adjust_steps), Motor.ANTICLOCKWISE)
 
     print('Aligned to initial position')
 

--- a/rig_funcs.py
+++ b/rig_funcs.py
@@ -245,6 +245,8 @@ def fireLaser(laserPin,duration):
 #%% Functions for running the Session Gui    
 AbortEvent = threading.Event()
 TrialEvent = threading.Event()
+cleanRun = threading.Event()
+
 lickQueue = queue.Queue()
 timerQueue = queue.Queue()
 trialQueue = queue.Queue()
@@ -274,6 +276,11 @@ def TrialGui(paramsFile, outputFile, subjID):
         if abortSession:
             AbortEvent.set()
             sessionGUI.destroy()  # Destroy the Toplevel window
+            if not cleanRun.is_set():
+                easygui.msgbox(msg="Session was interrupted: Check terminal for errors", title="Session Interrupted")
+            else:
+                easygui.msgbox(msg="Remove rat from the box to its home cage", title="Session Finished")
+
             if not isChild: trialRoot.destroy()    # Destroy the hidden root window
         else:
             pass


### PR DESCRIPTION
Moved the end of session popup to the main thread, and fixed an error produced when attempting to print lick counts in sessions aborted before lick arrays are created