### PR TITLE
19 allow tubeseq to be empty

### DIFF
--- a/MakeParams.py
+++ b/MakeParams.py
@@ -319,7 +319,10 @@ def readParameters(paramsFile):
             LickCount = list([None])
         LickCount = [intOrNone(trialN) for trialN in LickCount]
         TubeSeq = [line[1].split(',') for line in paramsData if 'TubeSeq' in line[0]][0]
-        TubeSeq = [int(trialN) for trialN in TubeSeq]
+        if TubeSeq[0] == '':
+            TubeSeq = ["Rand"]*NTrials
+        else:
+            TubeSeq = [int(trialN) for trialN in TubeSeq]
         IPITimes = [line[1].split(',') for line in paramsData if 'IPITimes' in line[0]][0]
         IPITimes = [int(trialN)/1000 for trialN in IPITimes if len(trialN) != 0]
         IPImin = [int(line[1]) for line in paramsData if 'IPImin' in line[0]][0]
@@ -401,7 +404,10 @@ def readParameters(paramsFile):
         IntanPins = [line[1].split(',') for line in paramsData if 'IntanPins' in line[0]][0]
         IntanPins = [int(trialN) for trialN in IntanPins]
         TubeSeq = [line[1].split(',') for line in paramsData if 'TubeSeq' in line[0]][0]
-        TubeSeq = [int(trialN) for trialN in TubeSeq]
+        if TubeSeq[0] == '':
+            TubeSeq = ["Rand"]*NTrials
+        else:
+            TubeSeq = [int(trialN) for trialN in TubeSeq]
         IPITimes = [line[1].split(',') for line in paramsData if 'IPITimes' in line[0]][0]
         IPITimes = [int(trialN)/1000 for trialN in IPITimes if len(trialN) != 0]
         IPImin = [int(line[1]) for line in paramsData if 'IPImin' in line[0]][0]

--- a/MakeParams.py
+++ b/MakeParams.py
@@ -291,7 +291,7 @@ def makeParams(defaultVersion="PhotoBAT"):
         
         return outFile
 
-def readParameters(paramsFile):
+def readParameters(paramsFile, randSeq = None):
     try:
         with open(paramsFile, 'r') as params:
             paramsData = params.readlines()
@@ -319,8 +319,16 @@ def readParameters(paramsFile):
             LickCount = list([None])
         LickCount = [intOrNone(trialN) for trialN in LickCount]
         TubeSeq = [line[1].split(',') for line in paramsData if 'TubeSeq' in line[0]][0]
-        if TubeSeq[0] == '':
-            TubeSeq = ["Rand"]*NTrials
+        if randSeq is not None:
+            TubeSeq = randSeq
+        elif TubeSeq[0] == '': #If TubeSeq is empty, fill it
+            Positions = np.arange(2,(len(Solutions)*2)+2,2)[[posN != '' for posN in Solutions]]
+            NBlocks = round(np.ceil(NTrials/len(Positions)))
+            SeqTemp = []
+            for BLockN in range(NBlocks):
+                SeqTemp.extend(random.sample(list(Positions), len(Positions)))
+            TubeSeq = SeqTemp[:NTrials]
+            easygui.msgbox(msg="Tube sequence is empty. A random sequence will be generated when running session. The sequence shown here is for example purposes only.", title="Example Sequence")
         else:
             TubeSeq = [int(trialN) for trialN in TubeSeq]
         IPITimes = [line[1].split(',') for line in paramsData if 'IPITimes' in line[0]][0]

--- a/MakeParams.py
+++ b/MakeParams.py
@@ -346,14 +346,19 @@ def readParameters(paramsFile):
         
         tastes = [stimN for stimN in Solutions if len(stimN) > 0]
         concs = [stimN for stimN in Concentrations if len(stimN) > 0]
-        if isDav:
-            taste_positions = [int(stimN+1) for stimN in range(len(Solutions)) if len(Solutions[stimN]) > 0]
-            tasteList =  [Solutions[tubeN-1] for tubeN in TubeSeq]
-            concList =  [Concentrations[tubeN-1] for tubeN in TubeSeq]
+
+        if TubeSeq[0] == "Rand":
+            tasteList = TubeSeq
+            concList = TubeSeq
         else:
-            taste_positions = [2*int(stimN+1) for stimN in range(len(Solutions)) if len(Solutions[stimN]) > 0]
-            tasteList =  [Solutions[int(tubeN/2)-1] for tubeN in TubeSeq]
-            concList =  [Concentrations[int(tubeN/2)-1] for tubeN in TubeSeq]
+            if isDav:
+                taste_positions = [int(stimN+1) for stimN in range(len(Solutions)) if len(Solutions[stimN]) > 0]
+                tasteList =  [Solutions[tubeN-1] for tubeN in TubeSeq]
+                concList =  [Concentrations[tubeN-1] for tubeN in TubeSeq]
+            else:
+                taste_positions = [2*int(stimN+1) for stimN in range(len(Solutions)) if len(Solutions[stimN]) > 0]
+                tasteList =  [Solutions[int(tubeN/2)-1] for tubeN in TubeSeq]
+                concList =  [Concentrations[int(tubeN/2)-1] for tubeN in TubeSeq]
         stimList = [f'{concList[trialN]} {tasteList[trialN]}' for trialN in range(NTrials)]
         
         #Set Lick Time List

--- a/licking_MCC.py
+++ b/licking_MCC.py
@@ -101,6 +101,12 @@ if args.paramsFile is None:
 
 # Setup trial parameters
 if paramsFile is not None:
+    #Setup Messages
+    trialMsg = ''
+    IPIMsg = ''
+    licktimeMsg = ''
+    waitMsg = ''
+
     with open(paramsFile, 'r') as params:
         paramsData = params.readlines()
     paramsData = [line.rstrip('\n') for line in paramsData]
@@ -121,7 +127,16 @@ if paramsFile is not None:
         LickCount = list([None])
     LickCount = [intOrNone(trialN) for trialN in LickCount]
     TubeSeq = [line[1].split(',') for line in paramsData if 'TubeSeq' in line[0]][0]
-    TubeSeq = [int(trialN) for trialN in TubeSeq]
+    if TubeSeq[0] == '': #If TubeSeq is empty, fill it
+        Positions = np.arange(1,len(Concentrations)+1,1)[[posN != '' for posN in Concentrations]]
+        NBlocks = round(np.ceil(NTrials/len(Positions)))
+        SeqTemp = []
+        for BLockN in range(NBlocks):
+            SeqTemp.extend(random.sample(list(Positions), len(Positions)))
+        TubeSeq = SeqTemp[:NTrials]
+        trialMsg = '-TubeSeq is empty; generating random sequence\n'
+    else:
+        TubeSeq = [int(trialN) for trialN in TubeSeq]
     IPITimes = [line[1].split(',') for line in paramsData if 'IPITimes' in line[0]][0]
     IPITimes = [int(trialN)/1000 for trialN in IPITimes if len(trialN) != 0]
     IPImin = [int(line[1]) for line in paramsData if 'IPImin' in line[0]][0]
@@ -137,17 +152,15 @@ if paramsFile is not None:
         useCamera = [line[1] for line in paramsData if 'UseCamera' in line[0]][0]
     except:
         useCamera = useCamera
-    
+    try:
+        useLaser = [line[1].split(',') for line in paramsData if 'UseLaser' in line[0]][0]
+    except:
+        useLaser = [False]
+
     tastes = [stimN for stimN in Solutions if len(stimN) > 0]
     taste_positions = [int(stimN+1) for stimN in range(len(Solutions)) if len(Solutions[stimN]) > 0]
     concs = [stimN for stimN in Concentrations if len(stimN) > 0]
-    
-    #Setup Messages
-    trialMsg = ''
-    IPIMsg = ''
-    licktimeMsg = ''
-    waitMsg = ''
-    
+      
     #Set Lick Time List
     if len(LickTime) < NTrials:
         LickTime = (LickTime * -(-NTrials//len(LickTime)))[:NTrials]

--- a/licking_MCC.py
+++ b/licking_MCC.py
@@ -135,8 +135,10 @@ if paramsFile is not None:
             SeqTemp.extend(random.sample(list(Positions), len(Positions)))
         TubeSeq = SeqTemp[:NTrials]
         trialMsg = '-TubeSeq is empty; generating random sequence\n'
+        randSeq = TubeSeq
     else:
         TubeSeq = [int(trialN) for trialN in TubeSeq]
+        randSeq = None
     IPITimes = [line[1].split(',') for line in paramsData if 'IPITimes' in line[0]][0]
     IPITimes = [int(trialN)/1000 for trialN in IPITimes if len(trialN) != 0]
     IPImin = [int(line[1]) for line in paramsData if 'IPImin' in line[0]][0]
@@ -397,7 +399,7 @@ rig.TrialEvent.set() #Set the trial event, which will be turned off to start the
 rig.cleanRun.clear()
 
 def runSession():
-    #Final Check
+    #Final Check, wait for GUI
     while rig.AbortEvent.is_set():
         try:
             time.sleep(0.001)
@@ -609,4 +611,4 @@ def runSession():
 #%%
 sessionThread = threading.Thread(target=runSession,daemon=False)
 sessionThread.start()
-rig.TrialGui(paramsFile, outputFile, subjID)
+rig.TrialGui(paramsFile, outputFile, subjID, randSeq = randSeq)

--- a/licking_beambk_Camera.py
+++ b/licking_beambk_Camera.py
@@ -108,6 +108,12 @@ NSpouts = len(spoutAddress)
 lickMode = rigParams['lickMode']
 
 if paramsFile is not None:
+    #Setup Messages
+    trialMsg = ''
+    IPIMsg = ''
+    licktimeMsg = ''
+    waitMsg = ''
+
     with open(paramsFile, 'r') as params:
         paramsData = params.readlines()
     paramsData = [line.rstrip('\n') for line in paramsData]
@@ -128,7 +134,16 @@ if paramsFile is not None:
         LickCount = list([None])
     LickCount = [intOrNone(trialN) for trialN in LickCount]
     TubeSeq = [line[1].split(',') for line in paramsData if 'TubeSeq' in line[0]][0]
-    TubeSeq = [int(trialN) for trialN in TubeSeq]
+    if TubeSeq[0] == '': #If TubeSeq is empty, fill it
+        Positions = np.arange(2,(len(Concentrations)*2)+2,2)[[posN != '' for posN in Concentrations]]
+        NBlocks = round(np.ceil(NTrials/len(Positions)))
+        SeqTemp = []
+        for BLockN in range(NBlocks):
+            SeqTemp.extend(random.sample(list(Positions), len(Positions)))
+        TubeSeq = SeqTemp[:NTrials]
+        trialMsg = '-TubeSeq is empty; generating random sequence\n'
+    else:
+        TubeSeq = [int(trialN) for trialN in TubeSeq]
     IPITimes = [line[1].split(',') for line in paramsData if 'IPITimes' in line[0]][0]
     IPITimes = [int(trialN)/1000 for trialN in IPITimes if len(trialN) != 0]
     IPImin = [int(line[1]) for line in paramsData if 'IPImin' in line[0]][0]
@@ -152,13 +167,7 @@ if paramsFile is not None:
     tastes = [stimN for stimN in Solutions if len(stimN) > 0]
     taste_positions = [2*int(stimN+1) for stimN in range(len(Solutions)) if len(Solutions[stimN]) > 0]
     concs = [stimN for stimN in Concentrations if len(stimN) > 0]
-    
-    #Setup Messages
-    trialMsg = ''
-    IPIMsg = ''
-    licktimeMsg = ''
-    waitMsg = ''
-    
+      
     #Set Lick Time List
     if len(LickTime) < NTrials:
         LickTime = (LickTime * -(-NTrials//len(LickTime)))[:NTrials]

--- a/licking_beambk_Camera.py
+++ b/licking_beambk_Camera.py
@@ -135,15 +135,17 @@ if paramsFile is not None:
     LickCount = [intOrNone(trialN) for trialN in LickCount]
     TubeSeq = [line[1].split(',') for line in paramsData if 'TubeSeq' in line[0]][0]
     if TubeSeq[0] == '': #If TubeSeq is empty, fill it
-        Positions = np.arange(2,(len(Concentrations)*2)+2,2)[[posN != '' for posN in Concentrations]]
+        Positions = np.arange(2,(len(Solutions)*2)+2,2)[[posN != '' for posN in Solutions]]
         NBlocks = round(np.ceil(NTrials/len(Positions)))
         SeqTemp = []
         for BLockN in range(NBlocks):
             SeqTemp.extend(random.sample(list(Positions), len(Positions)))
         TubeSeq = SeqTemp[:NTrials]
         trialMsg = '-TubeSeq is empty; generating random sequence\n'
+        randSeq = TubeSeq
     else:
         TubeSeq = [int(trialN) for trialN in TubeSeq]
+        randSeq = None
     IPITimes = [line[1].split(',') for line in paramsData if 'IPITimes' in line[0]][0]
     IPITimes = [int(trialN)/1000 for trialN in IPITimes if len(trialN) != 0]
     IPImin = [int(line[1]) for line in paramsData if 'IPImin' in line[0]][0]
@@ -441,6 +443,8 @@ def runSession():
         cur_pos = rest_pos
 
         print('\n=== Press Ctrl-C to abort session ===\n')
+
+        # Wait for Session to Begin, triggered by GUI
         while rig.AbortEvent.is_set():
             try:
                 time.sleep(0.001)
@@ -729,4 +733,4 @@ def runSession():
 #%%
 sessionThread = threading.Thread(target=runSession,daemon=False)
 sessionThread.start()
-rig.TrialGui(paramsFile, outputFile, subjID)
+rig.TrialGui(paramsFile, outputFile, subjID, randSeq = randSeq)

--- a/rig_funcs.py
+++ b/rig_funcs.py
@@ -260,7 +260,7 @@ if Debug: #Debugging
     outputFile = '/home/ramartin/PhotoBAT/data/20250204/20250204None.txt'
     
 
-def TrialGui(paramsFile, outputFile, subjID):
+def TrialGui(paramsFile, outputFile, subjID, randSeq = None):
     #Make tables that don't allow editing
     class passiveTableCanvas(tkintertable.TableCanvas):
         def __init__(self, master=None, *args, **kw):
@@ -362,7 +362,7 @@ def TrialGui(paramsFile, outputFile, subjID):
     else:
         isChild = True
         trialRoot = tk._default_root  # Use the existing root
-    version, paramsData = readParameters(paramsFile)
+    version, paramsData = readParameters(paramsFile, randSeq = randSeq)
     sessionGUI = tk.Toplevel(trialRoot)
     sessionGUI.title(f"BAT Session: {subjID}")
     sessionGUI.protocol("WM_DELETE_WINDOW", on_close)


### PR DESCRIPTION
Fairly simple: if the tube sequence in the params file is left empty, then the sequence should be randomly generated, using the stimuli listed to specify blocks and the ntrials listed to give the length of session. There was a bit of fiddlyness to do with previewing the session from the main gui, but that's mostly figured out now.